### PR TITLE
mysqlのパフォーマンス改善

### DIFF
--- a/isuconp.sql
+++ b/isuconp.sql
@@ -1,4 +1,4 @@
-Enter password: 
+mysqldump: [Warning] Using a password on the command line interface can be insecure.
 -- MySQL dump 10.13  Distrib 8.0.35, for Linux (aarch64)
 --
 -- Host: localhost    Database: isuconp
@@ -29,8 +29,9 @@ CREATE TABLE `comments` (
   `user_id` int NOT NULL,
   `comment` text NOT NULL,
   `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  PRIMARY KEY (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=100037 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+  PRIMARY KEY (`id`),
+  KEY `idx_post_id` (`post_id`)
+) ENGINE=InnoDB AUTO_INCREMENT=100241 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -48,7 +49,7 @@ CREATE TABLE `posts` (
   `body` text NOT NULL,
   `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=10037 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=10187 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -67,7 +68,7 @@ CREATE TABLE `users` (
   `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
   PRIMARY KEY (`id`),
   UNIQUE KEY `account_name` (`account_name`)
-) ENGINE=InnoDB AUTO_INCREMENT=1127 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=1343 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
 
@@ -79,4 +80,4 @@ CREATE TABLE `users` (
 /*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
 /*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
 
--- Dump completed on 2023-11-24  8:11:57
+-- Dump completed on 2023-11-24  9:00:10


### PR DESCRIPTION
最初のスコア
```
{"pass":true,"score":0,"success":144,"fail":65,
"messages":["リクエストがタイムアウトしました (GET /)",
"リクエストがタイムアウトしました (GET /@alta)",
"リクエストがタイムアウトしました (GET /@anita)",
"リクエストがタイムアウトしました (GET /@cheryl)",
"リクエストがタイムアウトしました (GET /@hattie)",
"リクエストがタイムアウトしました (GET /@jocelyn)",
"リクエストがタイムアウトしました (GET /@kaitlin)",
"リクエストがタイムアウトしました (GET /@marion)",
"リクエストがタイムアウトしました (GET /@rosie)",
"リクエストがタイムアウトしました (GET /@shelley)",
"リクエストがタイムアウトしました (GET /@tamara)",
"リクエストがタイムアウトしました (GET /@tamika)",
"リクエストがタイムアウトしました (POST /login)",
"リクエストがタイムアウトしました (POST /register)"]}
```

mysqlのslow_query-logを確認して、気になった点とその解決方法は以下です。
### 1 comments テーブルから特定の post_id に対するコメントを検索するクエリ時間が長い
```
SELECT * FROM `comments` WHERE `post_id` = 954 ORDER BY `created_at` DESC LIMIT 3;
# Time: 2023-11-24T08:35:03.637018Z
# User@Host: root[root] @ webapp-app-1.webapp_default [172.20.0.4]  Id:   110
# Query_time: 5.519356  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100003
```
改善策
`post_id` に関連するコメントを高速に検索できるようにするために、post_id カラムにインデックスを追加しました。
`ALTER TABLE comments ADD INDEX idx_post_id (post_id);`でindexを貼りました。