### PR TITLE
app.goの変更

### DIFF
--- a/golang/app.go
+++ b/golang/app.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	crand "crypto/rand"
+	"crypto/sha512"
+	"encoding/hex"
 	"fmt"
 	"html/template"
 	"io"
@@ -9,7 +11,6 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"os/exec"
 	"path"
 	"regexp"
 	"strconv"
@@ -109,22 +110,10 @@ func validateUser(accountName, password string) bool {
 		regexp.MustCompile(`\A[0-9a-zA-Z_]{6,}\z`).MatchString(password)
 }
 
-// 今回のGo実装では言語側のエスケープの仕組みが使えないのでOSコマンドインジェクション対策できない
-// 取り急ぎPHPのescapeshellarg関数を参考に自前で実装
-// cf: http://jp2.php.net/manual/ja/function.escapeshellarg.php
-func escapeshellarg(arg string) string {
-	return "'" + strings.Replace(arg, "'", "'\\''", -1) + "'"
-}
-
 func digest(src string) string {
-	// opensslのバージョンによっては (stdin)= というのがつくので取る
-	out, err := exec.Command("/bin/bash", "-c", `printf "%s" `+escapeshellarg(src)+` | openssl dgst -sha512 | sed 's/^.*= //'`).Output()
-	if err != nil {
-		log.Print(err)
-		return ""
-	}
+	data := sha512.Sum512([]byte(src))
 
-	return strings.TrimSuffix(string(out), "\n")
+	return hex.EncodeToString(data[:])
 }
 
 func calculateSalt(accountName string) string {


### PR DESCRIPTION
PR https://github.com/yomek33/private-isu/pull/1 で以下のスコアになりました。その続きから。
```
{"pass":true,"score":32352,"success":29766,"fail":0,"messages":[]}
```
## 1. ハッシュを計算するのに、opensslコマンドを直接実行するのではなく、Goの標準ライブラリを用いる
外部プロセス(openssl)を呼び出して実行するよりもGoの標準ライブラリ(crypto/sha512)を使った方が
良いパフォーマンスで計算できると思います。
実行後スコア： `{"pass":true,"score":33451,"success":30785,"fail":0,"messages":[]}`
Reference: https://pkg.go.dev/crypto/sha512

## nginxで静的ファイルを配信する
静的ファイルはリバースプロキシから配信する
実行後スコア:
`{"pass":true,"score":35549,"success":32914,"fail":0,"messages":[]}`